### PR TITLE
fix(auth): catch unhandled Supabase exceptions in login/signup actions

### DIFF
--- a/web/app/(auth)/login/actions.ts
+++ b/web/app/(auth)/login/actions.ts
@@ -20,12 +20,19 @@ export async function loginAction(_prev: LoginState, formData: FormData): Promis
   }
 
   const supabase = await createClient()
-  const { error } = await supabase.auth.signInWithPassword({
-    email: parsed.data.email,
-    password: parsed.data.password,
-  })
 
-  if (error) {
+  let authError: string | null = null
+  try {
+    const { error } = await supabase.auth.signInWithPassword({
+      email: parsed.data.email,
+      password: parsed.data.password,
+    })
+    if (error) authError = error.message
+  } catch {
+    return { error: "Impossible de se connecter. Vérifiez votre connexion." }
+  }
+
+  if (authError) {
     return { error: "Email ou mot de passe incorrect" }
   }
 

--- a/web/app/(auth)/signup/actions.ts
+++ b/web/app/(auth)/signup/actions.ts
@@ -27,17 +27,21 @@ export async function signupAction(_prev: SignupState, formData: FormData): Prom
   const supabase = await createClient()
   const origin = process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3000"
 
-  const { error } = await supabase.auth.signUp({
-    email: parsed.data.email,
-    password: parsed.data.password,
-    options: {
-      data: { display_name: parsed.data.displayName },
-      emailRedirectTo: `${origin}/auth/callback`,
-    },
-  })
+  try {
+    const { error } = await supabase.auth.signUp({
+      email: parsed.data.email,
+      password: parsed.data.password,
+      options: {
+        data: { display_name: parsed.data.displayName },
+        emailRedirectTo: `${origin}/auth/callback`,
+      },
+    })
 
-  if (error) {
-    return { error: error.message }
+    if (error) {
+      return { error: error.message }
+    }
+  } catch {
+    return { error: "Impossible de créer le compte. Vérifiez votre connexion." }
   }
 
   return { success: true }


### PR DESCRIPTION
Without a .env.local, the Supabase client threw instead of returning an error object, causing Next.js to respond with an HTML error page. useActionState tried to parse it as JSON → "Unexpected token '<'".