### PR TITLE
fix(build): rename middleware.ts → proxy.ts — Next.js 16 convention

### DIFF
--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -2,7 +2,7 @@ import type { NextRequest } from "next/server"
 
 import { updateSession } from "@/lib/supabase/middleware"
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   return updateSession(request)
 }
 


### PR DESCRIPTION
Next.js 16 deprecates the "middleware" file convention in favor of "proxy". Keeping middleware.ts caused a name collision with the imported @/lib/supabase/middleware module, breaking the Edge Function deployment with:
  "The Edge Function 'middleware' is referencing unsupported modules"

Reverts the earlier rename. The original auth bug was caused by missing NEXT_PUBLIC_* env vars in the build, not the middleware file.